### PR TITLE
Convert to using cmake-js instead of gyp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.15)
+cmake_policy(SET CMP0091 NEW)
+cmake_policy(SET CMP0042 NEW)
+
+project (blocking-socket)
+
+add_definitions(-DNAPI_VERSION=8)
+
+include_directories(${CMAKE_JS_INC})
+
+file(GLOB SOURCE_FILES "blocking-socket.cc")
+
+add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES} ${CMAKE_JS_SRC})
+set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "" SUFFIX ".node")
+target_link_libraries(${PROJECT_NAME} ${CMAKE_JS_LIB})
+
+if(MSVC AND CMAKE_JS_NODELIB_DEF AND CMAKE_JS_NODELIB_TARGET)
+  # Generate node.lib
+  execute_process(COMMAND ${CMAKE_AR} /def:${CMAKE_JS_NODELIB_DEF} /out:${CMAKE_JS_NODELIB_TARGET} ${CMAKE_STATIC_LINKER_FLAGS})
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy(SET CMP0042 NEW)
 
 project (blocking-socket)
 
-add_definitions(-DNAPI_VERSION=8)
+add_definitions(-DNAPI_VERSION=4)
 
 include_directories(${CMAKE_JS_INC})
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,8 +1,0 @@
-{
-  "targets": [
-    {
-      "target_name": "addon",
-      "sources": [ "blocking-socket.cc" ]
-    }
-  ]
-}

--- a/package.json
+++ b/package.json
@@ -33,10 +33,12 @@
     "darwin",
     "linux"
   ],
-  "dependencies": {},
-  "devDependencies": {},
+  "dependencies": {
+    "cmake-js": "^7.2.1"
+  },
   "directories": {},
   "scripts": {
-    "test": "./test/test.sh"
+    "test": "./test/test.sh",
+    "install": "cmake-js compile"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,5 +39,9 @@
   "scripts": {
     "test": "./test/test.sh",
     "install": "cmake-js compile"
+  },
+  "cmake-js": {
+    "runtime": "node",
+    "runtimeVersion": "8.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
   },
   "main": "./build/Release/addon.node",
   "files": [
-    "blocking-socket.cc",
-    "binding.gyp"
+    "blocking-socket.cc"
   ],
   "engines": {
     "node": ">= 0.12.x"


### PR DESCRIPTION
> CMake.js is a Node.js native addon build tool which works (almost) exactly like [node-gyp](https://github.com/TooTallNate/node-gyp), but instead of [gyp](http://en.wikipedia.org/wiki/GYP_%28software%29), it is based on [CMake](http://cmake.org/) build system.

node-gyp seems to still be stuck on python 2.7 (which went EOL in 2020) ([source](https://github.com/tree-sitter/tree-sitter/issues/175#issue-331864009)). this replaces it with something better


**testing performed**

ran `npm install --save ../path/to/blocking-socket` from another project
observed it installed without errors